### PR TITLE
Update notebook for Python 3

### DIFF
--- a/notebooks/multi_convnet_sentiment_classifier.ipynb
+++ b/notebooks/multi_convnet_sentiment_classifier.ipynb
@@ -170,7 +170,7 @@
     "dense_layer = Dense(n_dense, \n",
     "                    activation='relu', name='dense')(concat)\n",
     "drop_dense_layer = Dropout(dropout, name='drop_dense')(dense_layer)\n",
-    "dense_2 = Dense(n_dense/4, \n",
+    "dense_2 = Dense(n_dense//4, \n",
     "                activation='relu', name='dense_2')(drop_dense_layer)\n",
     "dropout_2 = Dropout(dropout, name='drop_dense_2')(dense_2)\n",
     "\n",


### PR DESCRIPTION
With Python 3.x (and the docker image shows version 3.6.7) we need to explcitly use integer (aka floor) division, otherwise Keras throws:

```
TypeError: Value passed to parameter 'shape' has DataType float32 not in list of allowed values: int32, int64
```

for instance:

```
>>> 256/4
64.0
>>> 256//4
64
```