### PR TITLE
Fix the link to the colab notebook

### DIFF
--- a/notebooks/generative_adversarial_network.ipynb
+++ b/notebooks/generative_adversarial_network.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/the-deep-learners/deep-learning-illustrated/blob/master/notebooks/cross_entropy_cost.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/the-deep-learners/deep-learning-illustrated/blob/master/notebooks/generative_adversarial_network.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Fix the link to point to the same notebook in Google colab environment.