### PR TITLE
Additions/enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ USER $NB_USER
 # install the libraries
 RUN \
 	# Upgrade pip first
-	pip install --upgrade pip==19.0.3 && \
+	pip install --upgrade pip && \
 	# TensorFlow. Note: was 1.0* so this conforms on the MAJOR version. Thus should be backward compatible, except tf.contrib
 	pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp36-cp36m-linux_x86_64.whl && \
 	# TFlearn, Keras, PyTorch, Torchvision, NLP libraries and RL environment

--- a/installation/step_by_step_MacOSX_install.md
+++ b/installation/step_by_step_MacOSX_install.md
@@ -1,38 +1,37 @@
 # Step-by-Step Instructions for macOS
 
-These instructions enable you to run TensorFlow code from the comfort of interactive Jupyter notebooks. Jupyter is itself run from within a Docker container because this ensures that you'll have all of the software dependencies you need while simultaneously preventing these dependencies from clashing with the software you already have installed on your system. 
+These instructions enable you to run TensorFlow code from the comfort of interactive Jupyter notebooks. Jupyter is itself run from within a Docker container because this ensures that you'll have all of the software dependencies you need while simultaneously preventing these dependencies from clashing with the software you already have installed on your system.
 
 ## Install
 
 1. Open the Terminal application ([like this](http://www.wikihow.com/Open-a-Terminal-Window-in-Mac))
 2. To install in your home directory (this is my recommended default):
-	* Type `cd ~` into the command-line prompt and 
+	* Type `cd ~` into the command-line prompt and
 	* *Execute* the line by pressing the **return** key on your keyboard
-3. Retrieve all of the code for this LiveLessons by executing `git clone https://github.com/illustrated-series/deep-learning-illustrated.git` (if you haven't used `git` before, you may be prompted to install Xcode -- do it!)
+3. Retrieve all of the code for this LiveLessons by executing `git clone https://github.com/the-deep-learners/deep-learning-illustrated` (if you haven't used `git` before, you may be prompted to install Xcode -- do it!)
 4. [Install the Docker "Stable channel"](https://docs.docker.com/docker-for-mac/install/) (if you are already using an older version of Docker and run into installation issues downstream, try updating to the latest version of Docker)
 5. Start Docker, e.g., by using Finder to navigate to your Applications folder and double-clicking on the Docker icon
-6. Back in Terminal, execute `source deep-learning-illustrated/installation/let_jovyan_write.sh` so that you can write to files in the *deep-learning-illustrated* directory from inside the Docker container we'll be creating momentarily 
+6. Back in Terminal, execute `source deep-learning-illustrated/installation/let_jovyan_write.sh` so that you can write to files in the *deep-learning-illustrated* directory from inside the Docker container we'll be creating momentarily
 7. Move into the *deep-learning-illustrated* directory by executing `cd deep-learning-illustrated`
 8. Build the Docker container by executing `sudo docker build -t dli-stack .` (you'll get an error if you miss the final `.`!)
-9. When that build process has finished, run the Docker container by executing `sudo docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-stack`
-10. In the web browser of your choice (e.g., Chrome), copy and paste the URL created by Docker (this begins with `http://localhost:8888/?token=` and should be visible near the bottom of your Terminal window) 
+9. When that build process has finished, run the Docker container by executing `sudo docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-stack`. For your convenience there is a bash script, **rundocker.sh** that executes the same command, so you can simply run `source rundocker.sh`. This command must be executed from the directory where you cloned the repository.
+10. In the web browser of your choice (e.g., Chrome), copy and paste the URL created by Docker (this begins with `http://localhost:8888/?token=` and should be visible near the bottom of your Terminal window)
 
 ## Shutdown
 
-You can shutdown the Jupyter notebook by returning to the Terminal session that is running it and hitting the **control** and **c** keys simultaneously on your keyboard. 
+You can shutdown the Jupyter notebook by returning to the Terminal session that is running it and hitting the **control** and **c** keys simultaneously on your keyboard.
 
 ## Restart
 
-You can restart the Jupyter notebook later by following steps nine and ten alone. 
+You can restart the Jupyter notebook later by following steps nine and ten alone.
 
 ## Bonus: Training Models with an Nvidia GPU
 
-You don't need to train your Deep Learning models with a GPU for this course, but some of the later notebooks in these LiveLessons will run much more quickly if you do. 
+You don't need to train your Deep Learning models with a GPU for this course, but some of the later notebooks in these LiveLessons will run much more quickly if you do.
 
 1. Install an [Nvidia GPU](http://www.nvidia.com/content/global/global.php) on your machine or spin up a cloud instance that includes one (typically a Tesla K80)
 1. Install CUDA and cuDNN, e.g., per the **Installing CUDA Toolkit** and **Installing cuDNN** sections of [this blog post](https://hackernoon.com/launch-a-gpu-backed-google-compute-engine-instance-and-setup-tensorflow-keras-and-jupyter-902369ed5272) (this step may be tricky if you're relatively new to working with the Unix command line)
 2. In the `deep-learning-illustrated/installation/docker-stack-scripts` directory:
 	* run `chmod 777 jupyter_notebook_config.py start*.sh`
 3. Replace step eight of my **Install** section above with `sudo docker build -f Dockerfile-gpu -t dli-gpu-stack .`
-4. Replace step nine with `sudo nvidia-docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-gpu-stack`
-
+4. Replace step nine with `sudo nvidia-docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-gpu-stack` or simply run `source rundocker-gpu.sh` from the main repository directory.

--- a/installation/step_by_step_Windows_Docker_install.md
+++ b/installation/step_by_step_Windows_Docker_install.md
@@ -1,14 +1,14 @@
 # Step-by-Step Instructions for Windows
 
-These instructions enable you to run TensorFlow code from the comfort of interactive Jupyter notebooks. Jupyter is itself run from within a Docker container because this ensures that you'll have all of the software dependencies you need while simultaneously preventing these dependencies from clashing with the software you already have installed on your system. 
+These instructions enable you to run TensorFlow code from the comfort of interactive Jupyter notebooks. Jupyter is itself run from within a Docker container because this ensures that you'll have all of the software dependencies you need while simultaneously preventing these dependencies from clashing with the software you already have installed on your system.
 
 Please note that **to use Docker on Windows**, you will need a 64-bit installation of Windows 10 Professional or Enterprise.
 
 1. Install [Docker Community Edition for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows). You may need to log out and/or reboot to complete the installation.
 2. Install [SourceTree](https://www.sourcetreeapp.com/).
-3. Using SourceTree, clone the repository at `https://github.com/illustrated-series/deep-learning-illustrated.git`. Note the directory which you used for this clone.
+3. Using SourceTree, clone the repository at `https://github.com/the-deep-learners/deep-learning-illustrated`. Note the directory which you used for this clone.
 4. Right-click on the Docker "whale" icon in the system tray and select "Settings..." followed by "Shared Drives". Ensure that the drive which you used for the checkout is marked as shared; you will need to enter your Windows password and restart Docker at this point.
 5. Start a PowerShell prompt and change into the directory where you cloned the repository.
 6. Build the Docker container by executing `docker build -t dli-stack .` (you'll get an error if you miss the final `.`!)
-7. When that build process has finished, run the Docker container by executing `docker run -v c:/full/path/to/the/clone:/home/jovyan/work -it --rm -p 8888:8888 dli-stack`.
-8. In the web browser of your choice (e.g., Chrome), copy and paste the URL created by Docker (this begins with `http://localhost:8888/?token=` and should be visible near the bottom of your Terminal window) 
+7. When that build process has finished, run the Docker container by executing `docker run -v %cd%:/home/jovyan/work -it --rm -p 8888:8888 dli-stack`. For your convenience there's also a Windows batch file, **rundocker.bat** that executes the same command, so you can simply run `rundocker.bat` from the directory where you cloned the repository.
+8. In the web browser of your choice (e.g., Chrome), copy and paste the URL created by Docker (this begins with `http://localhost:8888/?token=` and should be visible near the bottom of your Terminal window)

--- a/rundocker-gpu.sh
+++ b/rundocker-gpu.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo nvidia-docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-gpu-stack

--- a/rundocker.bat
+++ b/rundocker.bat
@@ -1,0 +1,1 @@
+docker run -v %cd%:/home/jovyan/work -it --rm -p 8888:8888 dli-stack

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-stack


### PR DESCRIPTION
- Add "convenience" scripts for both macOS and Windows to make starting Docker images easier -- so you can just type  `source rundocker.sh` instead of `sudo docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 dli-stack`

- Update documentation accordingly

- Update Docker file to install latest **pip**