### PR TITLE
Add image building before running the containter

### DIFF
--- a/rundocker.bat
+++ b/rundocker.bat
@@ -1,1 +1,2 @@
+docker build -t dli-stack .
 docker run -v %cd%:/home/jovyan/work -it --rm -p 8888:8888 -p 6006:6006 dli-stack

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+sudo docker build -t dli-stack .
 sudo docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 -p 6006:6006 dli-stack


### PR DESCRIPTION
While I was trying to use the rundocker/bat script I've got an error about missing dli-stack container, which is not available in public Docker registry, so the image needs to be built first, with this dli-stack tag.

I've added line doing exactly that to both .bat and .sh files